### PR TITLE
Fix hamburger when new tabs are enabled

### DIFF
--- a/discordfx/layout/_master.tmpl
+++ b/discordfx/layout/_master.tmpl
@@ -13,7 +13,7 @@
   <body>
         <div class="top-navbar">
 
-            <a href="javascript:void(0);" class="burger-icon" onclick="toggleMenu()">
+            <a class="burger-icon" onclick="toggleMenu()">
                 <svg name="Hamburger" 
                     style="vertical-align: middle;"
                     width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M20 6H4V9H20V6ZM4 10.999H20V13.999H4V10.999ZM4 15.999H20V18.999H4V15.999Z"></path></svg>


### PR DESCRIPTION
If `"_enableNewTab": true` is set in metadata then the hamburger menu opens a new blank tab every time it is clicked. This fixes that issue.