### PR TITLE
Fix hiding elements on mobile

### DIFF
--- a/discordfx/styles/discord.css
+++ b/discordfx/styles/discord.css
@@ -551,16 +551,11 @@ code
     float: right;
 }
 
-.mobile-hide 
-{
-    visibility: hidden;
-}
-
-@media (min-width: 1024px) 
+@media (max-width: 1023.98px) 
 {
     .mobile-hide 
     {
-        visibility: visible;
+        display: none;
     }
 }
 


### PR DESCRIPTION
Using `visibility` leaves the elements in the layout so they still interfere with the positioning of other items. On mobile devices that means the "pull-right" elements push down the content below the heading if the title is wide. Doing it this way will remove them from the layout completely so they aren't messing with visible content.