### PR TITLE
Fix for nested unordered list not showing in article

### DIFF
--- a/demo/articles/intro.md
+++ b/demo/articles/intro.md
@@ -69,9 +69,35 @@ Troes](http://tamen.io/). Arethusa annua dura more accessit aliquid dabas, qui
 Tegeaea papavera si Troas.
 
 - Vota ipsa in peremi
+  1. nested ordered list
+  2. inposuere incubat thalamo
+  3. legi robora: plus arbor latrator
 - Possent anhelatos
 - Poena quem
+  - Pictas leto vix novem
+    - Studeat occupat viro talia
+    - Acies in vulnere secum
+  - Busto siquid adspexerit
+  - Arethusa annua dura
 - Nutrit super eodem
+  - Cremarat mutare advehar:
+    ```cpp
+    #define X(ot) 0
+    
+    #undef X
+
+    #ifdef X 
+    static char t = 't';
+    #endif
+
+    // dsdfsd
+    /* d d */
+    std::string InteractObjective::verb() const
+    {
+        int a = 0;
+        return m_verb;
+    }
+    ```
 - Donis adhaesit requiemque petit Antaeo sustinet feram
 
 Studeat occupat viro talia truncas pectine redit crimina divum illud, precesque

--- a/discordfx/styles/discord.css
+++ b/discordfx/styles/discord.css
@@ -58,6 +58,11 @@ ul > li, ol > li {
     display: list-item;
 }
 
+article li > ul
+{
+    display: block;
+}
+
 h1,h2,h3,h4,h5 
 {
     color: var(--link-active-color);


### PR DESCRIPTION
Nested unordered lists were hidden for the sidebar, but it's also affected nested unordered lists in the article. This makes them show again in the article only. Note: I used `display:block` because `display:list-item` was creating an extra bullet point for some reason.

Edited demo article to show it. Note: Only unordered lists were affected, but I also added a nested ordered list in the demo article.