### PR TITLE
Fix view source and improve this doc links not clickable

### DIFF
--- a/discordfx/styles/discord.css
+++ b/discordfx/styles/discord.css
@@ -643,6 +643,11 @@ code
     margin: 0 5px;
 }
 
+article span.small.pull-right {
+    z-index: 999;
+    position: relative;
+}
+
 li 
 {
     display: block;

--- a/discordfx/styles/discord.css
+++ b/discordfx/styles/discord.css
@@ -639,6 +639,10 @@ code
     }
 }
 
+.divider {
+    margin: 0 5px;
+}
+
 li 
 {
     display: block;


### PR DESCRIPTION
View Source and Improve this Doc links in API documentation are not clickable

Expected Behavior: 
After navigating to a class or interface in API documentation, I should be able to click any of the View Source links or the Improve this Doc links for it to navigate to the correct GitHub page.

Actual Behavior:
Both links are visible but not clickable