### PR TITLE
Fix update highlight.js version and add CDN link for jquery.mark.js

### DIFF
--- a/discordfx/partials/head.tmpl.partial
+++ b/discordfx/partials/head.tmpl.partial
@@ -10,7 +10,7 @@
   {{#_description}}<meta name="description" content="{{_description}}">{{/_description}}
   <link rel="shortcut icon" href="{{_rel}}{{{_appFaviconPath}}}{{^_appFaviconPath}}favicon.ico{{/_appFaviconPath}}">
   <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500;700&display=swap" rel="stylesheet">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/night-owl.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/styles/night-owl.min.css">
   <link rel="stylesheet" href="{{_rel}}styles/colors.css">
   <link rel="stylesheet" href="{{_rel}}styles/discord.css">
   <link rel="stylesheet" href="{{_rel}}styles/main.css">

--- a/discordfx/partials/scripts.tmpl.partial
+++ b/discordfx/partials/scripts.tmpl.partial
@@ -1,9 +1,10 @@
 {{!Copyright (c) Microsoft. All rights reserved. Licensed under the MIT license. See LICENSE file in the project root for full license information.}}
 
 <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+<script src="https://cdn.jsdelivr.net/npm/mark.js@8.11.1/dist/jquery.mark.min.js" integrity="sha256-4HLtjeVgH0eIB3aZ9mLYF6E8oU5chNdjU6p6rrXpl9U=" crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js" integrity="sha384-Q6E9RHvbIyZFJoft+2mJbHaEWldlvI9IOYy5n3zV9zzTtmI3UksdQRVvoxMfooAo" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.5.0/js/bootstrap.min.js" integrity="sha384-OgVRvuATP1z7JjHLkuOU7Xw704+h835Lr+6QL9UvYjZE3Ipu6Tp75j7Bh/kR0JKI" crossorigin="anonymous"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.7.0/highlight.min.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/jquery.twbsPagination.js"></script>
 <script type="text/javascript" src="{{_rel}}styles/url.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/anchor-js/anchor.min.js"></script>


### PR DESCRIPTION
Fix #23, Fix #25

This PR updates the default template to correspond to the current latest DocFX 2.67.5 update.

## How to fix
I suggest a patch to update the highlight.js link in the templates to the latest hosted version 11.7.0.
I also suggest adding a CDN link for jquery.mark.min.js.
These fixes ensure that errors and display disturbances that occur when using the current DocFx version are suppressed.

## Relevant information
About #23, This PR also relates to and follows the following DocFx issue: dotnet/docfx#8873 